### PR TITLE
explicitly set discriminants for generic commands

### DIFF
--- a/src/protocol/channels/generic_channel.rs
+++ b/src/protocol/channels/generic_channel.rs
@@ -1,22 +1,22 @@
-use crate::protocol::commands::{GetMsgPayload, SetMsgPayload};
+use crate::protocol::commands::{GetMsgPayload, SetMsgPayload, common_command_discriminants};
 use crate::protocol::message::CommandTrait;
 use crate::protocol::CanMessageData;
 use zerocopy::{FromZeros, IntoBytes};
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes};
 
-/*#[derive(Debug)]
+#[derive(Debug)]
 #[repr(isize)]
 //TODO @Michael do you know of a way to make the enum variants have payloads and also have discriminants?
 pub enum GenericCommand{
-    GenericReqResetAllSettings = CommonReqResetSettings as isize,	// NO payload
-    GenericResResetAllSettings = CommonResResetSettings as isize,	// NO payload
-    GenericReqStatus = CommonReqStatus as isize,					// NO payload
-    GenericResStatus = CommonResStatus as isize,					// TODO: some status msg
-    GenericReqSetVariable{payload: SetMsgPayload} = CommonReqSetVariable as isize,		// SetMsg_t
-    GenericResSetVariable{payload: SetMsgPayload} = CommonResSetVariable as isize,		    // SetMsg_t
-    GenericReqGetVariable{payload: GetMsgPayload} = CommonReqGetVariable as isize,		    // GetMsg_t
-    GenericResGetVariable{payload: SetMsgPayload} = CommonResGetVariable as isize,		    // SetMsg_t
-    GenericReqSyncClock = CommonTotalCmds as isize,				    // NO FUCKING IDEA
+    GenericReqResetAllSettings = common_command_discriminants::REQ_RESET_SETTINGS,	// NO payload
+    GenericResResetAllSettings = common_command_discriminants::RES_RESET_SETTINGS,	// NO payload
+    GenericReqStatus = common_command_discriminants::REQ_STATUS,					// NO payload
+    GenericResStatus = common_command_discriminants::RES_STATUS,					// TODO: some status msg
+    GenericReqSetVariable{payload: SetMsgPayload} = common_command_discriminants::REQ_SET_VARIABLE,		// SetMsg_t
+    GenericResSetVariable{payload: SetMsgPayload} = common_command_discriminants::RES_SET_VARIABLE,		    // SetMsg_t
+    GenericReqGetVariable{payload: GetMsgPayload} = common_command_discriminants::REQ_GET_VARIABLE,		    // GetMsg_t
+    GenericResGetVariable{payload: SetMsgPayload} = common_command_discriminants::RES_GET_VARIABLE,		    // SetMsg_t
+    GenericReqSyncClock,				    // NO FUCKING IDEA
     GenericResSyncClock,								        	// NO FUCKING IDEA
     GenericReqData,									            	// NO payload
     GenericResData{payload: HeartBeatDataMsg},                      // DataMsg_t
@@ -29,34 +29,8 @@ pub enum GenericCommand{
     GenericReqFlashClear,							            	// NO payload
     GenericResFlashStatus{status: u8},                              // FlashStatusMsg_t //TODO find a way to
     GenericTotalCmds
-}*/
-
-#[derive(Debug)]
-#[repr(isize)]
-//TODO This is "Wrong" since the enum variants with payloads do not have discriminants. Find a way to fix this in the future.
-pub enum GenericCommand {
-    GenericReqResetAllSettings,                       // NO payload
-    GenericResResetAllSettings,                       // NO payload
-    GenericReqStatus,                                 // NO payload
-    GenericResStatus,                                 // TODO: some status msg
-    GenericReqSetVariable { payload: SetMsgPayload }, // SetMsg_t
-    GenericResSetVariable { payload: SetMsgPayload }, // SetMsg_t
-    GenericReqGetVariable { payload: GetMsgPayload }, // GetMsg_t
-    GenericResGetVariable { payload: SetMsgPayload }, // SetMsg_t
-    GenericReqSyncClock,                              // NO FUCKING IDEA
-    GenericResSyncClock,                              // NO FUCKING IDEA
-    GenericReqData,                                   // NO payload
-    GenericResData { payload: HeartBeatDataMsg },     // DataMsg_t
-    GenericReqNodeInfo,                               // NO payload
-    GenericResNodeInfo { payload: NodeInfoMsg },      // NodeInfoMsg_t
-    GenericReqNodeStatus,                             // NO payload
-    GenericResNodeStatus, // NodeStatusMsg_t //TODO Ignoring parameters since it's unused. Remove in the future
-    GenericReqSpeaker,    // SpeakerMsg_t //TODO Ignoring parameters since it's unused. Remove in the future
-    GenericReqThreshold,  // ThresholdMsg_t //TODO Ignoring parameters since it's unused. Remove in the future
-    GenericReqFlashClear, // NO payload
-    GenericResFlashStatus { status: u8 }, // FlashStatusMsg_t //TODO find a way to
-    GenericTotalCmds,
 }
+
 pub enum GenericCommandDiscriminant {
     GenericReqResetAllSettings = 0,
     GenericResResetAllSettings = 1,

--- a/src/protocol/commands.rs
+++ b/src/protocol/commands.rs
@@ -1,17 +1,37 @@
 use zerocopy_derive::{FromBytes, Immutable, IntoBytes};
 
+pub mod common_command_discriminants {
+    pub const REQ_RESET_SETTINGS: isize = 0;
+    pub const RES_RESET_SETTINGS: isize = 1;
+    pub const REQ_STATUS: isize = 2;
+    pub const RES_STATUS: isize = 3;
+    pub const REQ_SET_VARIABLE: isize = 4;
+    pub const RES_SET_VARIABLE: isize = 5;
+    pub const REQ_GET_VARIABLE: isize = 6;
+    pub const RES_GET_VARIABLE: isize = 7;
+    pub const COMMON_TOTAL_CMDS: isize = 8;
+}
+
 #[repr(isize)]
 pub enum CommonCommands {
-    CommonReqResetSettings = 0,                          // NO payload
-    CommonResResetSettings = 1,                          // NO payload
-    CommonReqStatus = 2,                                 // NO payload
-    CommonResStatus = 3,                                 // TODO: some status msg
-    CommonReqSetVariable { payload: SetMsgPayload } = 4, // SetMsg_t
-    CommonResSetVariable { payload: SetMsgPayload } = 5, // SetMsg_t
-    CommonReqGetVariable { payload: GetMsgPayload } = 6, // GetMsg_t
-    CommonResGetVariable { payload: SetMsgPayload } = 7, // SetMsg_t
+    CommonReqResetSettings = common_command_discriminants::REQ_RESET_SETTINGS, // NO payload
+    CommonResResetSettings = common_command_discriminants::RES_RESET_SETTINGS, // NO payload
+    CommonReqStatus = common_command_discriminants::REQ_STATUS,                // NO payload
+    CommonResStatus = common_command_discriminants::RES_STATUS, // TODO: some status msg
+    CommonReqSetVariable {
+        payload: SetMsgPayload,
+    } = common_command_discriminants::REQ_SET_VARIABLE, // SetMsg_t
+    CommonResSetVariable {
+        payload: SetMsgPayload,
+    } = common_command_discriminants::RES_SET_VARIABLE, // SetMsg_t
+    CommonReqGetVariable {
+        payload: GetMsgPayload,
+    } = common_command_discriminants::REQ_GET_VARIABLE, // GetMsg_t
+    CommonResGetVariable {
+        payload: SetMsgPayload,
+    } = common_command_discriminants::RES_GET_VARIABLE, // SetMsg_t
 
-    CommonTotalCmds,
+    CommonTotalCmds = common_command_discriminants::COMMON_TOTAL_CMDS,
 }
 impl From<CommonCommands> for u8 {
     fn from(value: CommonCommands) -> Self {


### PR DESCRIPTION
Not sure what the best solution here is. This is just one possibility.

In this PR I added `common_command_discriminants`, which can easily be re-used for assigning the discriminant for different enums.

Alternatively, it is possible to get the discriminant of a `repr(isize)` enum by this function:
```rust
impl CommonCommands {
    pub const fn discriminant(&self) -> isize {
        // SAFETY: Because `CommonCommands` is marked `repr(isize)`, its layout is a `repr(C)` `union`
        // between `repr(C)` structs, each of which has the `isize` discriminant as its first
        // field, so we can read the discriminant without offsetting the pointer.
        unsafe {
            let ptr = self as *const Self;
            let discriminant_ptr = ptr.cast::<isize>();
            *discriminant_ptr
        }
    }
}
```
Since this function is `const`, it would be possible to use it use it in the discriminant assignment, e.g.
```rust
pub enum GenericCommand{
    GenericReqResetAllSettings = CommonCommands::CommonReqResetSettings.discriminant()
...
```

The reason why we can't do `CommonCommands::CommonReqResetSettings as isize` is that `CommonCommands` is not a field-less enum, so on the other hand e.g. `GenericCommandDiscriminant::GenericReqResetAllSettings as isize` would not be a problem. So we could also do
``` rust
pub enum GenericCommand{
    GenericReqResetAllSettings = GenericCommandDiscriminant::GenericReqResetAllSettings as isize
...
```

For reference the section about discriminants in the rust reference: https://doc.rust-lang.org/reference/items/enumerations.html#discriminants

Just opening this PR to show you some of my thoughts, would be interested what you think!
